### PR TITLE
Include vanilla-framework through a symlink

### DIFF
--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -1,0 +1,6 @@
+// import required files
+
+@import 'global-settings';
+
+@import 'lib/vanilla-framework/scss/vanilla';
+@include vanilla;

--- a/scss/lib/vanilla-framework
+++ b/scss/lib/vanilla-framework
@@ -1,0 +1,1 @@
+../../node_modules/vanilla-framework

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -1,5 +1,0 @@
-// import required files
-
-@import 'global-settings';
-
-@import '../node_modules/vanilla-framework/scss/styles';


### PR DESCRIPTION
This means that the import statement doesn't need to use "../"
which fails in pyscss. 'Cos we use pyscss.