### PR TITLE
add canonical.com typography

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -510,6 +510,12 @@
                     </div>
                 </div>
             </div>
+            <div class="row row-hero">
+                <div class="inner-wrapper">
+                    <h2>Code</h2>
+                    <code>function fooBar() { echo 'foo'; }</code>
+                </div>
+            </div>
             <div class="row row-hero no-border">
                 <div class="inner-wrapper">
                     <h2>Page hero</h2>

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -5,8 +5,10 @@
 // import required files
 @import '../node_modules/vanilla-framework/scss/vanilla';
 @import 'modules/strips';
+@import 'modules/typography';
 
 @mixin canonical-vanilla-theme {
   @include vanilla;
   @include canonical-strips;
+  @include canonical-typography;
 }

--- a/scss/modules/_strips.scss
+++ b/scss/modules/_strips.scss
@@ -12,13 +12,17 @@
 
   .strip-dark {
     background-color: $dark-aubergine;
-    ///background-image: url('../img/backgrounds/background-grid.png');
+    background-image: url('http://www.canonical.com/static/img/backgrounds/background-grid.png');
     background-repeat: repeat;
     color: $light-link;
 
     &.solid {
       background-image: none;
       background-color: $dark-aubergine;
+    }
+
+    h1 {
+      color: $light-link;
     }
   }
 

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -1,0 +1,105 @@
+////
+/// @author       Web Team at Canonical Ltd
+////
+
+/// Typographic element styles
+/// @group Typography
+@mixin canonical-typography {
+  h1 {
+    color: $brand-color;
+    font-size: 1.625em;
+    margin-bottom: .5em;
+  }
+
+  h2 {
+    font-size: 1.438em;
+    margin-bottom: .5em;
+  }
+
+  h3 {
+    font-size: 1.219em;
+    margin-bottom: .522em;
+  }
+
+  h4 {
+    font-size: 1em;
+    font-weight: 400;
+    margin-bottom: .615em;
+  }
+
+  h5 {
+    font-size: .813em;
+    font-weight: 700;
+    margin-bottom: 1em;
+  }
+
+  h6 {
+    font-size: .723em;
+    font-weight: 400;
+    letter-spacing: .1em;
+    margin-bottom: 1em;
+    text-transform: uppercase;
+  }
+
+  p,
+  li {
+    font-size: 1em;
+    line-height: 1.5;
+    margin-bottom: .75em;
+    margin: 0;
+    padding: 0;
+  }
+
+  ol+h2, 
+  p+h2, 
+  pre+h2, 
+  ul+h2 {
+    margin-top: .563em;
+  }
+
+  ol+h3, 
+  p+h3, 
+  pre+h3, 
+  ul+h3 {
+    margin-top: .783em;
+  }
+
+  ol+h4, 
+  p+h4, 
+  pre+h4, 
+  ul+h4 { 
+    margin-top: 1.219em;
+  }
+
+  @media only screen and (min-width : 984px) {
+    h1 {
+      font-size: 2.8125em;
+    }
+
+    h2 {
+      font-size: 2em;
+      margin-bottom: .375em;
+    }
+
+    h3 {
+      font-size: 1.438em;
+      margin-bottom: .522em;
+    }
+
+    h4 {
+      font-size: 1em;
+      margin-bottom: .75em;
+    }
+
+    h5 { font-size: 1em; }
+
+    p,
+    li,
+    code,
+    pre {
+      font-size: 1em;
+      line-height: 1.5;
+      margin-bottom: .75em;
+    }
+  }
+}


### PR DESCRIPTION
Done:

Added typography from canonical.com to the theme.

QA:

 - node_modules should have the git bleeding-edge version of vanilla-framework
 - gulp build
 - check that the typography is correct (h1 in .hero should be purple, etc.)