### PR TITLE
add configuration and overrides for canonical header styling

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -28,3 +28,8 @@ $link-color: $secondary-color;
 
 /// Site maximum width
 $site-max-width: 984px;
+
+/// Nav colours
+$header-link-color: #fff;
+$header-light-border: #923266;
+$header-dark-border: #642246;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -4,11 +4,13 @@
 
 // import required files
 @import '../node_modules/vanilla-framework/scss/vanilla';
+@import 'modules/header';
 @import 'modules/strips';
 @import 'modules/typography';
 
 @mixin canonical-vanilla-theme {
   @include vanilla;
+  @include canonical-header;
   @include canonical-strips;
   @include canonical-typography;
 }

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -1,0 +1,55 @@
+////
+/// @author       Web Team at Canonical Ltd
+////
+
+/// header styles
+/// @group 
+@mixin canonical-header {
+  .banner .nav-primary ul {
+    border: 0;
+    display: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+
+    li {
+      border-right: 0;
+      width: 100%;
+    }
+
+    .nav-toggle {
+      display: block;
+    }
+  }
+
+
+  @media only screen and (min-width: $navigation-threshold) {
+    .banner .nav-primary ul {
+      border-left: 1px solid $header-dark-border;
+      border-right: 1px solid $header-light-border;
+      display: block;
+      width: auto;
+
+      li {
+        border-left: 0;
+        border-right: 0;
+        width: auto;
+
+        &:last-child {
+          border-right: 0;
+        }
+      }
+
+      a, 
+      a:link {
+        border-left: 1px solid $header-light-border;
+        border-right: 1px solid $header-dark-border;
+      }
+
+      a:hover {
+        background-color: $header-dark-border;
+        border-right: 1px solid transparent;
+      }
+    }
+  }
+}

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -11,26 +11,18 @@
     margin: 0;
     padding: 0;
     width: 100%;
-
-    li {
-      border-right: 0;
-      width: 100%;
-    }
-
-    .nav-toggle {
-      display: block;
-    }
-  }
-
-
-  @media only screen and (min-width: $navigation-threshold) {
-    .banner .nav-primary ul {
+    @media only screen and (min-width: $navigation-threshold) {
       border-left: 1px solid $header-dark-border;
       border-right: 1px solid $header-light-border;
       display: block;
       width: auto;
+    }
 
-      li {
+    li {
+      border-right: 0;
+      width: 100%;
+
+      @media only screen and (min-width: $navigation-threshold) {
         border-left: 0;
         border-right: 0;
         width: auto;
@@ -39,7 +31,9 @@
           border-right: 0;
         }
       }
+    }
 
+    @media only screen and (min-width: $navigation-threshold) {
       a, 
       a:link {
         border-left: 1px solid $header-light-border;
@@ -50,6 +44,10 @@
         background-color: $header-dark-border;
         border-right: 1px solid transparent;
       }
+    }
+
+    .nav-toggle {
+      display: block;
     }
   }
 }

--- a/scss/modules/_strips.scss
+++ b/scss/modules/_strips.scss
@@ -12,7 +12,9 @@
 
   .strip-dark {
     background-color: $dark-aubergine;
+    // scss-lint:disable UrlFormat
     background-image: url('http://www.canonical.com/static/img/backgrounds/background-grid.png');
+    // scss-lint:enable UrlFormat
     background-repeat: repeat;
     color: $light-link;
 


### PR DESCRIPTION
Done:
Added a new module and theme config to configure and override default vanilla header styles to match canonical.com

QA:

gulp build

Look at demo/index.html and compare the look/function with canonical.com's header at various viewports.