### PR TITLE
simple override for Vanilla's inline-logos

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -516,7 +516,7 @@
                     <code>function fooBar() { echo 'foo'; }</code>
                 </div>
             </div>
-            <div class="row row-hero no-border">
+            <div class="row row-hero">
                 <div class="inner-wrapper">
                     <h2>Page hero</h2>
                     <div class="six-col">
@@ -529,8 +529,26 @@
                     </div>
                 </div>
             </div>
+            <div class="row no-border">
+                <div class="inner-wrapper">
+                    <h2 class="muted-heading">A selection of customers using our services</h2>
+                    <ul class="inline-logos">
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-wikimedia-foundation.png" alt="Wikimedia logo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-bloomberg.png" alt="Bloomberg logo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-deutsche-telekom.png" alt="Deutsche Telekom logo"></li>
+                        <li class="last-item"><img src="http://www.canonical.com/static/img/logos/logo-intel.png" alt="Intel logo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-china-telecom.png" alt="China Telecom logo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-ebay.png" alt="Ebay logo"></li>
+                        <li class="last-item"><img src="http://www.canonical.com/static/img/logos/logo-windows-azure.png" alt="Windows Azurelogo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-samsung.png" alt="Samsung logo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-google.png" alt="Google logo"></li>
+                        <li><img src="http://www.canonical.com/static/img/logos/logo-ntt-communications.png" alt="NTT Communications logo"></li>
+                        <li class="last-item"><img src="http://www.canonical.com/static/img/logos/logo-mercado-libre.png" alt="Mercado libre logo"></li>
+                        <li class="last-item"><img src="http://www.canonical.com/static/img/logos/logo-cisco.png" alt="Cisco logo"></li>
+                    </ul>
+                </div>
+            </div>
         </div>
-    </div>
     <footer class="global clearfix no-global">
       <nav id="main-navigation" role="navigation" class="clearfix">
         <div class="legal clearfix has-cookie">

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -4,11 +4,13 @@
 
 // import required files
 @import '../node_modules/vanilla-framework/scss/vanilla';
+@import 'modules/inline-logos';
 @import 'modules/strips';
 @import 'modules/typography';
 
 @mixin canonical-vanilla-theme {
   @include vanilla;
+  @include canonical-inline-logos;
   @include canonical-strips;
   @include canonical-typography;
 }

--- a/scss/modules/_inline-logos.scss
+++ b/scss/modules/_inline-logos.scss
@@ -1,0 +1,17 @@
+////
+/// @author       Web Team at Canonical Ltd
+////
+
+/// Inline logos component
+/// @group Lists
+/// @example
+///   <ul class="inline-logos">
+///     <li>...</li>
+///   </ul>
+
+@mixin canonical-inline-logos {
+  .inline-logos li img {
+    max-width: 230px;
+    max-height: 65px;
+  }
+}

--- a/scss/modules/_strips.scss
+++ b/scss/modules/_strips.scss
@@ -12,7 +12,9 @@
 
   .strip-dark {
     background-color: $dark-aubergine;
+    // scss-lint:disable UrlFormat
     background-image: url('http://www.canonical.com/static/img/backgrounds/background-grid.png');
+    // scss-lint:enable UrlFormat
     background-repeat: repeat;
     color: $light-link;
 


### PR DESCRIPTION
Done:
 - Added an override for the sizing of inline-logos
 - Added a linter exception for a hard-coded image URL

Pre-requisites:
 - The bleeding-edge of vanilla from git

QA:
 - gulp build (if there are no linting errors then the exception works)
 - view demo/index.html and see that the logo block (bottom of the page) have a max width of 230px and a max height of 65px.