### PR TITLE
remove shadow at small viewport

### DIFF
--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -5,48 +5,52 @@
 /// header styles
 /// @group 
 @mixin canonical-header {
-  .banner .nav-primary ul {
-    border: 0;
-    display: none;
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    @media only screen and (min-width: $navigation-threshold) {
-      border-left: 1px solid $header-dark-border;
-      border-right: 1px solid $header-light-border;
-      display: block;
-      width: auto;
-    }
-
-    li {
-      border-right: 0;
+  .banner {
+    box-shadow: none;
+    
+    .nav-primary ul {
+      border: 0;
+      display: none;
+      margin: 0;
+      padding: 0;
       width: 100%;
-
       @media only screen and (min-width: $navigation-threshold) {
-        border-left: 0;
-        border-right: 0;
+        border-left: 1px solid $header-dark-border;
+        border-right: 1px solid $header-light-border;
+        display: block;
         width: auto;
+      }
 
-        &:last-child {
+      li {
+        border-right: 0;
+        width: 100%;
+
+        @media only screen and (min-width: $navigation-threshold) {
+          border-left: 0;
           border-right: 0;
-        }
+          width: auto;
 
-        a, 
-        a:link,
-        a:visited {
-          border-left: 1px solid $header-light-border;
-          border-right: 1px solid $header-dark-border;
-        }
+          &:last-child {
+            border-right: 0;
+          }
 
-        a:hover {
-          background-color: $header-dark-border;
-          border-right: 1px solid transparent;
+          a, 
+          a:link,
+          a:visited {
+            border-left: 1px solid $header-light-border;
+            border-right: 1px solid $header-dark-border;
+          }
+
+          a:hover {
+            background-color: $header-dark-border;
+            border-right: 1px solid transparent;
+          }
         }
       }
-    }
 
-    .nav-toggle {
-      display: block;
+      .nav-toggle {
+        display: block;
+      }
     }
   }
 }

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -5,6 +5,7 @@
 /// header styles
 /// @group 
 @mixin canonical-header {
+  // scss-lint:disable NestingDepth
   .banner {
     box-shadow: none;
     
@@ -53,4 +54,5 @@
       }
     }
   }
+  // scss-lint:enable NestingDepth
 }


### PR DESCRIPTION
Done:
Fixed nav at small viewport

QA:
Pull into the node_modules directory of a checkout of canonical-website and pull the bleeding-edge version of vanilla-framework into that.

Check that there is no shadow under the nav at the small viewport.