### PR TITLE
bump vanilla-framework requirement to latest build

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/ubuntudesign/canonical-vanilla-theme"
   },
   "dependencies": {
-    "vanilla-framework": "0.0.13"
+    "vanilla-framework": "0.0.53"
   },
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
Done:
Upped the version of vanilla required by the project to the latest version

QA:
remove node_modules (if present) then:
 npm install
 gulp build
 test demo/index.html in-browser and check for any odd behaviour