### PR TITLE
add body module, add new theme settings and correct hard-coded screen…

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -19,6 +19,11 @@ $dark-aubergine: #2c001e;
 /// secondary color (ubuntu orange)
 $secondary-color: #dd4814;
 
+/// Used in overlay gradients
+$fade-color: #32001d;
+
+/// page background colour
+$site-background-color: #f1f1f1;
 
 /// light link
 $light-link: #fff;
@@ -28,6 +33,7 @@ $link-color: $secondary-color;
 
 /// Site maximum width
 $site-max-width: 984px;
+$content-max-width: 904px;
 
 /// Nav colours
 $header-link-color: #fff;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -4,6 +4,7 @@
 
 // import required files
 @import '../node_modules/vanilla-framework/scss/vanilla';
+@import 'modules/body';
 @import 'modules/forms';
 @import 'modules/header';
 @import 'modules/inline-logos';
@@ -12,6 +13,7 @@
 
 @mixin canonical-vanilla-theme {
   @include vanilla;
+  @include canonical-body;
   @include canonical-forms;
   @include canonical-header;
   @include canonical-inline-logos;

--- a/scss/modules/_body.scss
+++ b/scss/modules/_body.scss
@@ -1,0 +1,20 @@
+////
+/// @author Web Team at Canonical Ltd
+////
+
+/// body styles
+/// @group core
+
+@mixin canonical-body {
+  body {
+    height: 100%;
+    background-color: $site-background-color;
+    font-size: 14px;
+  }
+
+  @media only screen and (min-width: $site-max-width) {
+    body {
+      font-size: 16px;
+    }
+  }
+}

--- a/scss/modules/_strips.scss
+++ b/scss/modules/_strips.scss
@@ -3,8 +3,12 @@
 ////
 
 /// strip class styles
-/// @group 
+/// @group
 @mixin canonical-strips {
+  .inner-wrapper {
+    max-width: $content-max-width;
+  }
+
   .strip-dark,
   .strip-light {
     clear: both;


### PR DESCRIPTION
… size values to use variables

Done:
 - Added new variables to settings (not all used in the demo but important downstream) - content-max-width is notable for use in site structure.
 - Added a body module which includes CSS rules for the base <body> styles (Including site background colour)
 - Updated the strips module to use $content-max-width rather than a hard-coded value.

QA:
gulp build and check that the demo looks fine (background-color of <body> should be #f1f1f1