### PR TITLE
changed gutters in the footer to be optional

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -605,7 +605,7 @@
         <footer class="row strip footer">
             <div class="inner-wrapper">
                 <nav role="navigation">
-                    <div class="canonlist four-col">
+                    <div class="canonlist four-col footer__container--guttered">
                         <h2 class="footer__heading">Canonical</h2>
                         <ul class="compact-nav">
                             <li class="compact-nav__list-item">
@@ -628,7 +628,7 @@
                             </li>
                         </ul>
                     </div>
-                    <div class="five-col">
+                    <div class="five-col footer__container--guttered">
                         <h2 class="footer__heading">Follow us</h2>
                         <ul class="social-links">
                             <li class="social-links__item">
@@ -645,7 +645,7 @@
                             </li>
                         </ul>
                     </div>
-                    <div class="three-col last-col">
+                    <div class="three-col last-col footer__container--guttered">
                         <h2 class="footer__heading--external">Find out more</h2>
                         <ul class="external-link-list">
                             <li class="external-link-list__list-item">
@@ -663,7 +663,7 @@
                         </ul>
                     </div>
                 </nav>
-                <div class="legal twelve-col">
+                <div class="legal twelve-col footer__container--guttered">
                     <p class="legal__text">&copy; 2016 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
                     <ul class="legal__list">
                         <li class="legal__list-item">

--- a/scss/modules/_footer.scss
+++ b/scss/modules/_footer.scss
@@ -43,6 +43,19 @@
     }
   }
 
+  @media only screen and (max-width : 767px) {
+    .footer {
+      overflow: hidden;
+      padding-left: 0;
+      padding-right: 0;
+
+      &__container--guttered {
+        margin-right: 10px;
+        margin-left: 10px;
+      }
+    }
+  }
+
   .no-svg .footer__heading--external {
     background-image: url('https://assets.ubuntu.com/v1/e1b12fdd-external-link-grey.svg?fmt=png');
   }


### PR DESCRIPTION
### Done
restructured the footer to add a class to add optional gutters at small viewports (the menus on the actual site are full-width without gutters).

### QA
gulp build
view the demo in-browser and you should see no difference in the footer at small screen