### PR TITLE
bumped the version of gulp-sass required in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gulp-minify-css": "1.0.0",
     "gulp-notify": "2.2.0",
     "gulp-rename": "1.2.0",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "2.3.2",
     "gulp-scss-lint": "0.1.10",
     "gulp-util": "3.0.4",
     "sassdoc": "2.1.7"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gulp-minify-css": "1.0.0",
     "gulp-notify": "2.2.0",
     "gulp-rename": "1.2.0",
-    "gulp-sass": "1.3.3",
+    "gulp-sass": "^2.3.2",
     "gulp-scss-lint": "0.1.10",
     "gulp-util": "3.0.4",
     "sassdoc": "2.1.7"


### PR DESCRIPTION
### Done
Bumped the version of gulp-sass in the requirements from 1.3.3 to 2.3.2 to avoid errors on gulp build.

### QA
```npm i```
```gulp build```
See that there are no errors and the build completes